### PR TITLE
[Fix] typo in Q5340

### DIFF
--- a/thoonk/Deque/Q5340.swift
+++ b/thoonk/Deque/Q5340.swift
@@ -51,5 +51,5 @@ for _ in 0 ..< Int(readLine()!)! {
         .split(separator: ",")
         .map { Int(String($0))! }
     
-    print(oprt(&nums, by: p, n))
+    print(oprt(&nums, by: p))
 }


### PR DESCRIPTION
Fix parameter typo on function call
